### PR TITLE
【Fixed】Step2・辞書とタイムゾーンを日本仕様に設定、DB制約の定義

### DIFF
--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,7 +4,7 @@
       <th>content</th>
     </tr>
     <% @tasks.each do |task| %>
-      <tr>
+      <tr class="task_row">
         <td><%= link_to task_path(task.id), remote: true do %>
           <%= task.content %>
         <% end %></td>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ module TaskManager
   class Application < Rails::Application
     config.load_defaults 5.2
 
+    config.time_zone = "Tokyo"
+    
     config.generators do |g|
       g.javascripts false
       g.helper false

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,2 @@
+I18n.config.available_locales = :ja
+I18n.default_locale = :ja

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,206 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,13 @@
+ja:
+  activerecord:
+    models:
+      task: タスク
+      user: ユーザー
+      label: ラベル
+    attributes:
+      task:
+        content: 内容
+        detail: 詳細
+      user:
+        name: 名前
+        email: メールアドレス

--- a/db/migrate/20200609073819_change_column_options.rb
+++ b/db/migrate/20200609073819_change_column_options.rb
@@ -1,0 +1,6 @@
+class ChangeColumnOptions < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks, :content, :string, null: false, limit: 50
+    change_column :tasks, :detail, :text, limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_08_012942) do
+ActiveRecord::Schema.define(version: 2020_06_09_073819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "content"
+    t.string "content", limit: 50, null: false
     t.text "detail"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
-RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'タスク管理機能', type: :model do
+  it 'contentが空ならバリデーションが通らない' do
+    task = Task.new(content:"", detail: "失敗テスト")
+    expect(task).not_to be_valid
+  end
+  it 'contentが50文字以上ならバリデーションが通らない' do
+    task = Task.new(content:"#{ "あ" * 51 }", detail: "失敗テスト")
+    expect(task).not_to be_valid
+  end
+  it 'detailが空でもcontentが入力されていればバリデーションが通る' do
+    task = Task.new(content:"成功テスト", detail: "")
+    expect(task).to be_valid
+  end
+  it 'detailが255文字以上ならバリデーションが通らない' do
+    task = Task.new(content:"失敗テスト", detail: "#{ "f" * 260 }")
+    expect(task).not_to be_valid
+  end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,18 +1,42 @@
 require 'rails_helper'
 
+FactoryBot.define do
+  factory :task1, class: Task do
+    content { 'デフォルトの内容1' }
+    detail { 'デフォルトの詳細1' }
+  end
+  factory :task2, class: Task do
+    content { 'デフォルトの内容2' }
+    detail { 'デフォルトの詳細2'}
+  end
+end
+
 RSpec.describe 'Tasks', type: :system do
+  before do
+    # それぞれのテストケースで、before内のコードが実行
+    # 各テストで使用するタスクを1件作成する
+    # 作成したタスクオブジェクトを各テストケースで呼び出せるようにインスタンス変数に代入
+    @task = FactoryBot.create(:task1)
+  end
   describe 'タスク一覧画面' do
     context 'タスクを作成した場合' do
       # テストコードを it '~' do end ブロックの中に記載する
       it '作成済みのタスクが表示される' do
-        # テストで使用するためのタスクを作成
-        task = FactoryBot.create(:task, content: 'test_content')
         # タスク一覧ページに遷移
         visit tasks_path
         # visitした（遷移した）page（タスク一覧ページ）に「task」という文字列が
         # have_contentされているか。（含まれているか。）ということをexpectする（確認・期待する）
-        expect(page).to have_content 'test_content'
+        expect(page).to have_content 'デフォルトの内容1'
         # expectの結果が true ならテスト成功、false なら失敗として結果が出力される
+      end
+    end
+    context '複数のタスクを作成した場合' do
+      it 'タスクが作成日時の降順に並んでいる' do
+        new_task = FactoryBot.create(:task2)
+        visit tasks_path
+        task_list = all('.task_row')
+        expect(task_list[0]).to have_content 'デフォルトの内容2'
+        expect(task_list[1]).to have_content 'デフォルトの内容1'
       end
     end
   end
@@ -25,8 +49,8 @@ RSpec.describe 'Tasks', type: :system do
         click_link '+New'
         # contentというラベル名の入力欄と、detailというラベル名の入力欄に
         # タスクの内容と詳細をそれぞれfill_in(入力)する
-        fill_in 'Content', with: 'タスクデータが保存されるかテストする'
-        fill_in 'Detail', with: 'System　Specを使って必要項目を入力してcreateボタンを押した場合正しく保存されるかテストしている'
+        fill_in '内容', with: 'タスクデータが保存されるかテストする'
+        fill_in '詳細', with: 'System　Specを使って必要項目を入力してcreateボタンを押した場合正しく保存されるかテストしている'
         #「Create New Task」というvalueのあるボタンをclick_on(クリック)する
         click_button 'Create New Task'
         # タスク一覧ページにテストコードで作成したデータがhave_contentされているかを確認する
@@ -45,18 +69,16 @@ RSpec.describe 'Tasks', type: :system do
   describe 'タスク詳細画面' do
     context '任意のタスク詳細画面に遷移した場合' do
       it '該当タスクの内容が表示されたページに遷移する' do
-        # テストに使用するタスクデータを作成
-        task = FactoryBot.create(:task, content: 'test_show_content', detail: 'test_show_detail')
         # タスク一覧画面に遷移
         visit tasks_path
         # 作成したタスクデータのcontentの表示をクリック
         # 該当タスクの詳細ウィンドウが表示される
-        click_link 'test_show_content'
+        click_link 'デフォルトの内容1'
         # 詳細ウィンドウ内の検証
         within('.modal') do
           # 詳細ウィンドウに該当タスクのcontent,detailがhave_contentされているかを確認する
-          expect(page).to have_content 'test_show_content'
-          expect(page).to have_content 'test_show_detail'
+          expect(page).to have_content 'デフォルトの内容1'
+          expect(page).to have_content 'デフォルトの詳細1'
         end
        end
      end


### PR DESCRIPTION
-日本語の辞書ファイルを作成してエラーメッセージ等を日本語化した。
-モデル名・カラム名を日本語化した。
-DB制約を定義した。
-バリデーションテスト用のModel Specを記述した。

Taskモデルへのバリデーションの記述はstep1までに終えていたので省略しています。